### PR TITLE
REF: Adds cli.py and splits `create_output()` in two

### DIFF
--- a/mni_atlas_reader/__init__.py
+++ b/mni_atlas_reader/__init__.py
@@ -1,0 +1,4 @@
+__all__ = ['__version__', 'create_output']
+
+from mni_atlas_reader.info import __version__
+from mni_atlas_reader.atlas_reader import create_output

--- a/mni_atlas_reader/cli.py
+++ b/mni_atlas_reader/cli.py
@@ -1,0 +1,92 @@
+"""
+Functions for command line interface to generate cluster / peak summary
+"""
+import argparse
+import os.path as op
+from mni_atlas_reader.atlas_reader import (_ATLASES, check_atlases,
+                                           create_output)
+
+_ACCEPTED_ATLASES = _ATLASES + [a.lower() for a in _ATLASES]
+
+
+def _check_limit(num, limits=[0, 100]):
+    """
+    Ensures that `num` is within provided `limits`
+
+    Parameters
+    ----------
+    num : float
+        Number to assess
+    limits : list, optional
+        Lower and upper bounds that `num` must be between to be considered
+        valid
+    """
+    lo, hi = limits
+    num = float(num)
+
+    if num < lo or num > hi:
+        raise ValueError('Provided value {} is outside expected limits {}.'
+                         .format(num, limits))
+
+    return num
+
+
+def _get_parser():
+    """ Reads command line arguments and returns input specifications """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filename', type=op.abspath, metavar='file',
+                        help='The full or relative path to the statistical map'
+                             'from which cluster information should be '
+                             'extracted.')
+    parser.add_argument('-a', '--atlas', type=str, default='all', nargs='+',
+                        choices=_ACCEPTED_ATLASES + ['all'], metavar='atlas',
+                        help='Atlas(es) to use for examining anatomical '
+                             'delineation of clusters in provided statistical '
+                             'map. Default: all available atlases.')
+    parser.add_argument('-t', '--threshold', type=float, default=2,
+                        dest='voxel_thresh', metavar='threshold',
+                        help='Value threshold that voxels in provided file '
+                             'must surpass in order to be considered in '
+                             'cluster extraction.')
+    parser.add_argument('-c', '--cluster', type=float, default=5,
+                        dest='cluster_extent', metavar='extent',
+                        help='Required number of contiguous voxels for a '
+                             'cluster to be retained for analysis.')
+    parser.add_argument('-p', '--probability', type=_check_limit, default=5,
+                        dest='prob_thresh', metavar='threshold',
+                        help='Threshold to consider when using a '
+                             'probabilistic atlas for extracting anatomical '
+                             'cluster locations. Value will apply to all '
+                             'request probabilistic atlases, and should range '
+                             'between 0 and 100.')
+    parser.add_argument('-o', '--outdir', type=str, default=None,
+                        dest='outdir', metavar='outdir',
+                        help='Output directory for created files. If it is '
+                             'not specified, then output files are created in '
+                             'the same directory as the statistical map that '
+                             'is provided.')
+
+    return parser.parse_args()
+
+
+def main():
+    """
+    The primary entrypoint for calling atlas reader via the command line
+
+    All parameters are read via argparse, so this should only be called from
+    the command line!
+    """
+
+    opts = _get_parser()
+    create_output(opts.filename,
+                  atlas=check_atlases(opts.atlas),
+                  voxel_thresh=opts.voxel_thresh,
+                  cluster_extent=opts.cluster_extent,
+                  prob_thresh=opts.prob_thresh,
+                  outdir=opts.outdir)
+
+
+if __name__ == '__main__':
+    raise RuntimeError('`mni_atlas_reader/cli.py` should not be run '
+                       'directly. Please `pip install` mni_atlas_reader and '
+                       'use the `mni_atlas_reader` command, instead.')

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def main():
         license=ldict['LICENSE'],
         entry_points={
             'console_scripts': [
-                'mni_atlas_reader=mni_atlas_reader.atlas_reader:main'
+                'mni_atlas_reader=mni_atlas_reader.cli:main'
             ]
         }
     )


### PR DESCRIPTION
Closes #17.

Apologies for this rather massive refactor...

This PR:

1. Moves all command line interface (argparse, etc) from `atlas_reader.py` into `cli.py`,
2. Splits `create_output()` into two functions, `get_statmap_info()` and `create_output()`, where the former does most of the heavy lifting and the latter does file i/o, and
3. Modifies functions to use `nilearn` a bit more for safer image handling (and better python interfacing!).

I'd also like to clean up `read_atlas_cluster()` and `read_atlas_peak()` to be a bit faster (I'm pretty sure they can be sped up, and they _are_ the slowest part of the codebase right now!), but I think that might be best saved for another PR.

Let me know if you have any questions!